### PR TITLE
Categorisation typo

### DIFF
--- a/_posts/2019-01-30-getting-agile.md
+++ b/_posts/2019-01-30-getting-agile.md
@@ -3,7 +3,7 @@ title: Getting Agile!
 date: 2019-01-30 00:00:00 +0000
 categories:
 - agile
-- " training"
+- "training"
 
 ---
 ![Image showing the training room with people talking](/uploads/Academygroup.jpg "Training room")


### PR DESCRIPTION
Removed a leading space which has created an ugly URL `/agile/%20training/2019/01/30/getting-agile/`