### PR TITLE
fix: don't version Jekyll output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+### Jekyll ###
+_site/
+.sass-cache/
+.jekyll-cache/
+.jekyll-metadata
+
+### Ruby ###
+Gemfile.lock


### PR DESCRIPTION
Jekyll create files when running a build that we don't need to version in Git.
This tells Git to ignore those files.